### PR TITLE
change password request copy to password or token

### DIFF
--- a/src/pipelines/authentication.litcoffee
+++ b/src/pipelines/authentication.litcoffee
@@ -21,7 +21,7 @@ Stages of a pipeline to get login information.
             default: process.env.USER
             required: true
           password:
-            message: 'Your GitHub password'.magenta + ':'.bold
+            message: 'Your GitHub password or token'.magenta + ':'.bold
             default: process.env.PASSWORD
             required: true
             hidden: true


### PR DESCRIPTION
Because of MFA, we need to use a token instead of a password to auth on github API. change the password copy to be more clear that that's an option.